### PR TITLE
Fix service makefile image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -108,9 +108,10 @@ WORKDIR /config
 # 8843 - guest portal (https)
 # 8880 - guest portal (http)
 # 6789 - throughput / mobile speedtest (tcp)
+# 1900 - controller discovery (udp)
 # 10001 - device discovery (udp)
 # ref https://help.ubnt.com/hc/en-us/articles/218506997-UniFi-Ports-Used
-EXPOSE 3478/udp 8080 8081 8443 8843 8880 6789 10001/udp
+EXPOSE 3478/udp 8080 8081 8443 8843 8880 6789 10001/udp 1900/udp
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 

--- a/Makefile
+++ b/Makefile
@@ -30,24 +30,24 @@ docker-build: build
 .PHONY: build
 build:
 	# Build and tag images for quay.io
-	docker build . -f $(DOCKERFILE) -t $(QUAY_IMAGE_URI)
-	docker tag $(QUAY_IMAGE_URI) $(QUAY_IMAGE_URI_LATEST)
+	podman build --platform linux/arm . -f $(DOCKERFILE) -t $(QUAY_IMAGE_URI)
+	podman tag $(QUAY_IMAGE_URI) $(QUAY_IMAGE_URI_LATEST)
 	# Tag docker images
-	docker tag $(QUAY_IMAGE_URI) $(DOCKER_IMAGE_URI)
-	docker tag $(DOCKER_IMAGE_URI) $(DOCKER_IMAGE_URI_LATEST)
+	podman tag $(QUAY_IMAGE_URI) $(DOCKER_IMAGE_URI)
+	podman tag $(DOCKER_IMAGE_URI) $(DOCKER_IMAGE_URI_LATEST)
 
 .PHONY: push
 push:
 	# Push Quay.io images
-	docker push $(QUAY_IMAGE_URI)
-	docker push $(QUAY_IMAGE_URI_LATEST)
+	podman push $(QUAY_IMAGE_URI)
+	podman push $(QUAY_IMAGE_URI_LATEST)
 	# Push Docker images
-	docker push $(DOCKER_IMAGE_URI)
-	docker push $(DOCKER_IMAGE_URI_LATEST)
+	podman push $(DOCKER_IMAGE_URI)
+	podman push $(DOCKER_IMAGE_URI_LATEST)
 
 .PHONY: login
 login:
 	# Login to quay.io
-	docker login -u "$$QUAY_BOT_USERNAME" --password "$$QUAY_BOT_PASSWORD" quay.io
+	podman login -u "$$QUAY_BOT_USERNAME" --password "$$QUAY_BOT_PASSWORD" quay.io
 	# Login to docker
-	docker login -u "$$DOCKER_TOKEN" --password "$$DOCKER_SECRET_TOKEN"
+	podman login -u "$$DOCKER_TOKEN" --password "$$DOCKER_SECRET_TOKEN"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+kubectl apply -f manifests/namespace.yaml
+
+
+kubectl apply -f manifests/pv-volume.yaml
+kubectl apply -f manifests/pv-claim.yaml
+
+kubectl apply -f manifests/deployment.yaml
+
+kubectl apply -f manifests/service.yaml

--- a/manifests/deployment.yaml
+++ b/manifests/deployment.yaml
@@ -19,14 +19,14 @@ spec:
         app: unifi-controller
     spec:
       affinity:
-      nodeAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
-          nodeSelectorTerms:
-          - matchExpressions:
-            - key: kubernetes.io/hostname
-              operator: In
-              values:
-              - raspberrypi-kube-2
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/hostname
+                operator: In
+                values:
+                - raspberrypi-kube-2
       containers:
       - image: jharrington22/unifi-controller:test
         imagePullPolicy: Always

--- a/manifests/deployment.yaml
+++ b/manifests/deployment.yaml
@@ -28,7 +28,7 @@ spec:
                 values:
                 - raspberrypi-kube-2
       containers:
-      - image: jharrington22/unifi-controller:test
+      - image: quay.io/jharrington22/unifi-controller:v0.1.4-e6e3f8e
         imagePullPolicy: Always
         name: unifi-controller
         volumeMounts:

--- a/manifests/service-udp.yaml
+++ b/manifests/service-udp.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: unifi-controller
+  name: unifi-controller-udp
+  namespace: unifi-controller
+spec:
+  ports:
+  - name: device-discovery
+    port: 10001
+    protocol: UDP
+    targetPort: 10001
+  - name: controller-discovery
+    port: 1900
+    protocol: UDP
+    targetPort: 1900
+  - name: stun
+    port: 3478
+    protocol: UDP
+    targetPort: 3478
+  selector:
+    app: unifi-controller
+  type: LoadBalancer

--- a/manifests/service.yaml
+++ b/manifests/service.yaml
@@ -11,10 +11,6 @@ spec:
     port: 8443
     protocol: TCP
     targetPort: 8443
-  - name: stun
-    port: 3478
-    protocol: TCP
-    targetPort: 3478
   - name: device-inform
     port: 8080
     protocol: TCP
@@ -27,14 +23,6 @@ spec:
     port: 6789
     protocol: TCP
     targetPort: 6789
-  - name: device-discovery
-    port: 10001
-    protocol: UDP
-    targetPort: 10001
-  - name: controller-discovery
-    port: 1900
-    protocol: UDP
-    targetPort: 1900
   selector:
     app: unifi-controller
   type: LoadBalancer

--- a/manifests/service.yaml
+++ b/manifests/service.yaml
@@ -11,6 +11,30 @@ spec:
     port: 8443
     protocol: TCP
     targetPort: 8443
+  - name: stun
+    port: 3478
+    protocol: TCP
+    targetPort: 3478
+  - name: device-inform
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  - name: guest-portal
+    port: 8980
+    protocol: TCP
+    targetPort: 8880
+  - name: throughput-speedtest
+    port: 6789
+    protocol: TCP
+    targetPort: 6789
+  - name: device-discovery
+    port: 10001
+    protocol: UDP
+    targetPort: 10001
+  - name: controller-discovery
+    port: 1900
+    protocol: UDP
+    targetPort: 1900
   selector:
     app: unifi-controller
   type: LoadBalancer


### PR DESCRIPTION
This PR
- Adds controller discovery port
- Switches MakeFile builds to podman
- Fixes bug in Deployment manifests with `nodeAffinity` indentation
- Separates service for LoadBalancer into one for each UDP/TCP